### PR TITLE
Removing the G+ icon.

### DIFF
--- a/index.html
+++ b/index.html
@@ -301,7 +301,6 @@
             <li class="list-inline-item"><a href="#"><i class="fa fa-facebook"></i></a></li>
             <li class="list-inline-item"><a href="#2"><i class="fa fa-twitter"></i></a></li>
             <li class="list-inline-item"><a href="#"><i class="fa fa-instagram"></i></a></li>
-            <li class="list-inline-item"><a href="#"><i class="fa fa-google-plus"></i></a></li>
             <li class="list-inline-item"><a href="#" target="_blank"><i class="fa fa-envelope"></i></a></li>
           </ul>
         </div>


### PR DESCRIPTION
G+ is no more available to the public.